### PR TITLE
Change Logger Behaviour

### DIFF
--- a/waku/node.go
+++ b/waku/node.go
@@ -29,7 +29,6 @@ import (
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/multiformats/go-multiaddr"
 	rendezvous "github.com/status-im/go-waku-rendezvous"
-	"github.com/status-im/go-waku/tests"
 	"github.com/status-im/go-waku/waku/metrics"
 	"github.com/status-im/go-waku/waku/persistence"
 	"github.com/status-im/go-waku/waku/persistence/sqlite"
@@ -74,6 +73,7 @@ func freePort() (int, error) {
 
 // Execute starts a go-waku node with settings determined by the Options parameter
 func Execute(options Options) {
+	logger := utils.InitLogger(options.LogEncoding)
 	if options.GenerateKey {
 		if err := writePrivateKeyToFile(options.KeyFile, options.Overwrite); err != nil {
 			failOnErr(err, "nodekey error")
@@ -102,12 +102,12 @@ func Execute(options Options) {
 
 	var metricsServer *metrics.Server
 	if options.Metrics.Enable {
-		metricsServer = metrics.NewMetricsServer(options.Metrics.Address, options.Metrics.Port, tests.Logger())
+		metricsServer = metrics.NewMetricsServer(options.Metrics.Address, options.Metrics.Port, logger.Sugar())
 		go metricsServer.Start()
 	}
 
 	nodeOpts := []node.WakuNodeOption{
-		node.WithLogger(utils.Logger()),
+		node.WithLogger(logger),
 		node.WithPrivateKey(prvKey),
 		node.WithHostAddress(hostAddr),
 		node.WithKeepAlive(time.Duration(options.KeepAlive) * time.Second),
@@ -180,7 +180,7 @@ func Execute(options Options) {
 	if options.Store.Enable {
 		nodeOpts = append(nodeOpts, node.WithWakuStoreAndRetentionPolicy(options.Store.ShouldResume, options.Store.RetentionMaxDaysDuration(), options.Store.RetentionMaxMessages))
 		if options.UseDB {
-			dbStore, err := persistence.NewDBStore(tests.Logger(), persistence.WithDB(db), persistence.WithRetentionPolicy(options.Store.RetentionMaxMessages, options.Store.RetentionMaxDaysDuration()))
+			dbStore, err := persistence.NewDBStore(logger.Sugar(), persistence.WithDB(db), persistence.WithRetentionPolicy(options.Store.RetentionMaxMessages, options.Store.RetentionMaxDaysDuration()))
 			failOnErr(err, "DBStore")
 			nodeOpts = append(nodeOpts, node.WithMessageProvider(dbStore))
 		} else {
@@ -201,7 +201,7 @@ func Execute(options Options) {
 		for _, addr := range options.DiscV5.Nodes {
 			bootnode, err := enode.Parse(enode.ValidSchemes, addr)
 			if err != nil {
-				utils.Logger().Fatal("could not parse enr: ", zap.Error(err))
+				logger.Fatal("could not parse enr: ", zap.Error(err))
 			}
 			bootnodes = append(bootnodes, bootnode)
 		}
@@ -218,12 +218,12 @@ func Execute(options Options) {
 	addPeers(wakuNode, options.Filter.Nodes, filter.FilterID_v20beta1)
 
 	if err = wakuNode.Start(); err != nil {
-		utils.Logger().Fatal(fmt.Errorf("could not start waku node, %w", err).Error())
+		logger.Fatal(fmt.Errorf("could not start waku node, %w", err).Error())
 	}
 
 	if options.DiscV5.Enable {
 		if err = wakuNode.DiscV5().Start(); err != nil {
-			utils.Logger().Fatal(fmt.Errorf("could not start discovery v5, %w", err).Error())
+			logger.Fatal(fmt.Errorf("could not start discovery v5, %w", err).Error())
 		}
 	}
 
@@ -242,38 +242,38 @@ func Execute(options Options) {
 		go func(node string) {
 			err = wakuNode.DialPeer(ctx, node)
 			if err != nil {
-				utils.Logger().Error("error dialing peer ", zap.Error(err))
+				logger.Error("error dialing peer ", zap.Error(err))
 			}
 		}(n)
 	}
 
 	if options.DNSDiscovery.Enable {
 		if options.DNSDiscovery.URL != "" {
-			utils.Logger().Info("attempting DNS discovery with ", zap.String("URL", options.DNSDiscovery.URL))
+			logger.Info("attempting DNS discovery with ", zap.String("URL", options.DNSDiscovery.URL))
 			multiaddresses, err := dnsdisc.RetrieveNodes(ctx, options.DNSDiscovery.URL, dnsdisc.WithNameserver(options.DNSDiscovery.Nameserver))
 			if err != nil {
-				utils.Logger().Warn("dns discovery error ", zap.Error(err))
+				logger.Warn("dns discovery error ", zap.Error(err))
 			} else {
-				utils.Logger().Info("found dns entries ", zap.Any("multiaddresses", multiaddresses))
+				logger.Info("found dns entries ", zap.Any("multiaddresses", multiaddresses))
 				for _, m := range multiaddresses {
 					go func(ctx context.Context, m multiaddr.Multiaddr) {
 						ctx, cancel := context.WithTimeout(ctx, time.Duration(3)*time.Second)
 						defer cancel()
 						err = wakuNode.DialPeerWithMultiAddress(ctx, m)
 						if err != nil {
-							utils.Logger().Error("error dialing peer ", zap.Error(err))
+							logger.Error("error dialing peer ", zap.Error(err))
 						}
 					}(ctx, m)
 				}
 			}
 		} else {
-			utils.Logger().Fatal("DNS discovery URL is required")
+			logger.Fatal("DNS discovery URL is required")
 		}
 	}
 
 	var rpcServer *rpc.WakuRpc
 	if options.RPCServer.Enable {
-		rpcServer = rpc.NewWakuRpc(wakuNode, options.RPCServer.Address, options.RPCServer.Port, tests.Logger())
+		rpcServer = rpc.NewWakuRpc(wakuNode, options.RPCServer.Address, options.RPCServer.Port, logger.Sugar())
 		rpcServer.Start()
 	}
 
@@ -281,7 +281,7 @@ func Execute(options Options) {
 	ch := make(chan os.Signal, 1)
 	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
 	<-ch
-	utils.Logger().Info("Received signal, shutting down...")
+	logger.Info("Received signal, shutting down...")
 
 	// shut the node down
 	wakuNode.Stop()

--- a/waku/options.go
+++ b/waku/options.go
@@ -109,6 +109,7 @@ type Options struct {
 	AdvertiseAddress string   `long:"advertise-address" default:"" description:"External address to advertise to other nodes (overrides --address and --ws-address flags)"`
 	ShowAddresses    bool     `long:"show-addresses" description:"Display listening addresses according to current configuration"`
 	LogLevel         string   `short:"l" long:"log-level" description:"Define the logging level, supported strings are: DEBUG, INFO, WARN, ERROR, DPANIC, PANIC, FATAL, and their lower-case forms." default:"INFO"`
+	LogEncoding      string   `long:"log-encoding" description:"Log encoding format. Either console or json" choice:"console" choice:"json" default:"json"`
 
 	Relay            RelayOptions            `group:"Relay Options"`
 	Store            StoreOptions            `group:"Store Options"`

--- a/waku/v2/node/wakuoptions.go
+++ b/waku/v2/node/wakuoptions.go
@@ -80,7 +80,7 @@ type WakuNodeOption func(*WakuNodeParameters) error
 
 // Default options used in the libp2p node
 var DefaultWakuNodeOptions = []WakuNodeOption{
-	WithLogger(utils.Logger()),
+	WithLogger(utils.InitLogger("console")),
 	WithWakuRelay(),
 }
 

--- a/waku/v2/utils/logger.go
+++ b/waku/v2/utils/logger.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"fmt"
+
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -15,33 +17,39 @@ func SetLogLevel(level string) error {
 		return err
 	}
 	atom.SetLevel(lvl)
+
 	return nil
 }
 
 func Logger() *zap.Logger {
 	if log == nil {
-		cfg := zap.Config{
-			Encoding:         "console",
-			Level:            atom,
-			OutputPaths:      []string{"stderr"},
-			ErrorOutputPaths: []string{"stderr"},
-			EncoderConfig: zapcore.EncoderConfig{
-				MessageKey:   "message",
-				LevelKey:     "level",
-				EncodeLevel:  zapcore.CapitalLevelEncoder,
-				TimeKey:      "time",
-				EncodeTime:   zapcore.ISO8601TimeEncoder,
-				NameKey:      "caller",
-				EncodeCaller: zapcore.ShortCallerEncoder,
-			},
-		}
-
-		logger, err := cfg.Build()
-		if err != nil {
-			panic("could not create logger")
-		}
-
-		log = logger.Named("gowaku")
+		InitLogger("console").Panic("Logger not yet initialized")
 	}
+	return log
+}
+
+func InitLogger(logEncoding string) *zap.Logger {
+	cfg := zap.Config{
+		Encoding:         logEncoding,
+		Level:            atom,
+		OutputPaths:      []string{"stderr"},
+		ErrorOutputPaths: []string{"stderr"},
+		EncoderConfig: zapcore.EncoderConfig{
+			MessageKey:   "message",
+			LevelKey:     "level",
+			EncodeLevel:  zapcore.CapitalLevelEncoder,
+			TimeKey:      "time",
+			EncodeTime:   zapcore.ISO8601TimeEncoder,
+			NameKey:      "caller",
+			EncodeCaller: zapcore.ShortCallerEncoder,
+		},
+	}
+
+	logger, err := cfg.Build()
+	if err != nil {
+		panic(fmt.Sprintf("could not create logger (%s)", err))
+	}
+
+	log = logger.Named("gowaku")
 	return log
 }


### PR DESCRIPTION
## Problem
This addresses two issues in `go-waku`.
1. The Waku node is importing a logger from `testing`, which is ignored by the `.dockerignore` file breaking builds in Docker
2. There is no way to configure the log encoding from the command line

## Changes
This updates the Waku node to only use the Zap based logger. It creates a new command-line argument `--log-encoding` so that the encoding can be changed on the fly. It is recommended to use the `console` option when running locally and `json` when running in an environment where logs should be sent to DataDog.

In order to do this, I have added a new function `InitLogger`, which is called once during node setup. All calls to `utils.Logger()` then use the log instance created in this step. This is to avoid the need to pass the configuration value to all potential callers of the `utils.Logger`.

To run with JSON encoding you can now run `waku --log-encoding=json`

## Caveats
There is two small quirks to this.
1. Because the `DefaultWakuNodeOptions` array is initialized outside of any functions, I have to set the value to `console` there and initialize the logger (since this runs before anything else during `init()`). The logger is the re-initialized when the node starts up, and the configuration is overwritten. Not the most elegant, but it's the lowest impact change I could think of that reliably configured the logger.
2. `libp2p` uses its own logger, which is not affected by any of these configuration changes. I haven't looked into how that gets configured, but it can be handled as a separate PR if it is even possible.