### PR TITLE
Release Broadcaster Backpressure

### DIFF
--- a/waku/node.go
+++ b/waku/node.go
@@ -235,9 +235,7 @@ func Execute(options Options) {
 		for _, nodeTopic := range options.Relay.Topics {
 			sub, err := wakuNode.Relay().SubscribeToTopic(ctx, nodeTopic)
 			failOnErr(err, "Error subscring to topic")
-			ctxWithCancel, cancel := context.WithCancel(ctx)
-			go readSub(sub, ctxWithCancel)
-			defer cancel()
+			wakuNode.Broadcaster().Unregister(sub.C)
 		}
 	}
 
@@ -302,19 +300,6 @@ func Execute(options Options) {
 	if options.UseDB {
 		err = db.Close()
 		failOnErr(err, "DBClose")
-	}
-}
-
-func readSub(sub *relay.Subscription, ctx context.Context) {
-	for {
-		select {
-		case <-ctx.Done():
-			utils.Logger().Info("Stopping read from subscription")
-			return
-		case <-sub.C:
-			continue
-		}
-
 	}
 }
 

--- a/waku/node.go
+++ b/waku/node.go
@@ -235,6 +235,7 @@ func Execute(options Options) {
 		for _, nodeTopic := range options.Relay.Topics {
 			sub, err := wakuNode.Relay().SubscribeToTopic(ctx, nodeTopic)
 			failOnErr(err, "Error subscring to topic")
+			// Unregister from broadcaster. Otherwise this channel will fill until it blocks publishing
 			wakuNode.Broadcaster().Unregister(sub.C)
 		}
 	}

--- a/waku/node.go
+++ b/waku/node.go
@@ -236,7 +236,7 @@ func Execute(options Options) {
 			sub, err := wakuNode.Relay().SubscribeToTopic(ctx, nodeTopic)
 			failOnErr(err, "Error subscring to topic")
 			ctxWithCancel, cancel := context.WithCancel(ctx)
-			go readSub(sub, ctxWithCancel.Done())
+			go readSub(sub, ctxWithCancel)
 			defer cancel()
 		}
 	}
@@ -305,10 +305,10 @@ func Execute(options Options) {
 	}
 }
 
-func readSub(sub *relay.Subscription, quit <-chan struct{}) {
+func readSub(sub *relay.Subscription, ctx context.Context) {
 	for {
 		select {
-		case <-quit:
+		case <-ctx.Done():
 			utils.Logger().Info("Stopping read from subscription")
 			return
 		case <-sub.C:

--- a/waku/node.go
+++ b/waku/node.go
@@ -233,8 +233,9 @@ func Execute(options Options) {
 
 	if !options.Relay.Disable {
 		for _, nodeTopic := range options.Relay.Topics {
-			_, err := wakuNode.Relay().SubscribeToTopic(ctx, nodeTopic)
+			sub, err := wakuNode.Relay().SubscribeToTopic(ctx, nodeTopic)
 			failOnErr(err, "Error subscring to topic")
+			go readSub(sub)
 		}
 	}
 
@@ -299,6 +300,12 @@ func Execute(options Options) {
 	if options.UseDB {
 		err = db.Close()
 		failOnErr(err, "DBClose")
+	}
+}
+
+func readSub(sub *relay.Subscription) {
+	for {
+		<-sub.C
 	}
 }
 

--- a/waku/v2/node/wakunode2.go
+++ b/waku/v2/node/wakunode2.go
@@ -413,12 +413,13 @@ func (w *WakuNode) mountRelay(minRelayPeersToPublish int, opts ...pubsub.Option)
 		return err
 	}
 
-	if w.opts.enableRelay {
-		_, err = w.relay.Subscribe(w.ctx)
-		if err != nil {
-			return err
-		}
-	}
+	// if w.opts.enableRelay {
+	// 	sub, err := w.relay.Subscribe(w.ctx)
+	// 	if err != nil {
+	// 		return err
+	// 	}
+	// 	w.bcaster.Unregister(sub.C)
+	// }
 
 	// TODO: rlnRelay
 

--- a/waku/v2/node/wakunode2.go
+++ b/waku/v2/node/wakunode2.go
@@ -414,11 +414,10 @@ func (w *WakuNode) mountRelay(minRelayPeersToPublish int, opts ...pubsub.Option)
 	}
 
 	// if w.opts.enableRelay {
-	// 	sub, err := w.relay.Subscribe(w.ctx)
+	// 	_, err := w.relay.Subscribe(w.ctx)
 	// 	if err != nil {
 	// 		return err
 	// 	}
-	// 	w.bcaster.Unregister(sub.C)
 	// }
 
 	// TODO: rlnRelay


### PR DESCRIPTION
## Contents
- Unsubscribes unused channel from Broadcaster so that it does not block publishing
- Only creates one default subscription instead of two during app startup

## Background
Much more information can be found in [this thread](https://github.com/xmtp-labs/eng/issues/5#issuecomment-1032697994)