### PR TITLE
Parallel filter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,4 +29,5 @@ require (
 	github.com/urfave/cli/v2 v2.3.0
 	go.opencensus.io v0.23.0
 	go.uber.org/zap v1.19.0
+	golang.org/x/sync v0.0.0-20220513210516-0976fa681c29 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1256,6 +1256,8 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220513210516-0976fa681c29 h1:w8s32wxx3sY+OjLlv9qltkLU5yvJzxjjgiHWLjdIcw4=
+golang.org/x/sync v0.0.0-20220513210516-0976fa681c29/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180810173357-98c5dad5d1a0/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/waku/v2/protocol/filter/waku_filter.go
+++ b/waku/v2/protocol/filter/waku_filter.go
@@ -194,7 +194,7 @@ func (wf *WakuFilter) FilterListener() {
 	handle := func(envelope *protocol.Envelope) error { // async
 		msg := envelope.Message()
 		topic := envelope.PubsubTopic()
-		g, _ := errgroup.WithContext(context.Background())
+		g := new(errgroup.Group)
 		// Each subscriber is a light node that earlier on invoked
 		// a FilterRequest on this node
 		for subscriber := range wf.subscribers.Items() {

--- a/waku/v2/protocol/filter/waku_filter.go
+++ b/waku/v2/protocol/filter/waku_filter.go
@@ -194,6 +194,7 @@ func (wf *WakuFilter) FilterListener() {
 	handle := func(envelope *protocol.Envelope) error { // async
 		msg := envelope.Message()
 		topic := envelope.PubsubTopic()
+		g, _ := errgroup.WithContext(context.Background())
 		// Each subscriber is a light node that earlier on invoked
 		// a FilterRequest on this node
 		for subscriber := range wf.subscribers.Items() {

--- a/waku/v2/protocol/filter/waku_filter.go
+++ b/waku/v2/protocol/filter/waku_filter.go
@@ -209,8 +209,12 @@ func (wf *WakuFilter) FilterListener() {
 					wf.log.Info("found matching contentTopic ", filter, msg)
 					// Do a message push to light node
 					wf.log.Info("pushing messages to light node: ", subscriber.peer)
-					g.Go(func() error {
-						return wf.pushMessage(subscriber, msg)
+					g.Go(func() (err error) {
+						err = wf.pushMessage(subscriber, msg)
+						if err != nil {
+							wf.log.Error(err)
+						}
+						return err
 					})
 					// Break if we have found a match
 					break


### PR DESCRIPTION
## Summary
In debugging the Waku Filter implementation I found a new issue, separate from the others I was debugging.

A slow or disconnected Filter subscriber can block all other filter subscribers for many seconds, effectively halting all filter pushes.

With this fix, `go-waku`'s filter implementation actually works with browser based `js-waku` instances. My initial assessment that `go-waku` was not able to push to clients without an open listening address was incorrect, as the pushes were actually blocked by this issue. There is still an issue with `nwaku` servers pushing to the client, since `nwaku` does not re-use existing connections.