### PR TITLE
Allow lazy logger initialization

### DIFF
--- a/waku.go
+++ b/waku.go
@@ -363,6 +363,8 @@ func main() {
 				return err
 			}
 
+			utils.InitLogger(options.LogEncoding)
+
 			waku.Execute(options)
 			return nil
 		},

--- a/waku/metrics/http_test.go
+++ b/waku/metrics/http_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestStartAndStopMetricsServer(t *testing.T) {
-	server := NewMetricsServer("0.0.0.0", 9876, utils.InitLogger("console"))
+	server := NewMetricsServer("0.0.0.0", 9876, utils.Logger())
 
 	go func() {
 		time.Sleep(1 * time.Second)

--- a/waku/node.go
+++ b/waku/node.go
@@ -72,7 +72,6 @@ func freePort() (int, error) {
 
 // Execute starts a go-waku node with settings determined by the Options parameter
 func Execute(options Options) {
-	logger := utils.InitLogger(options.LogEncoding)
 	if options.GenerateKey {
 		if err := writePrivateKeyToFile(options.KeyFile, options.Overwrite); err != nil {
 			failOnErr(err, "nodekey error")
@@ -89,7 +88,7 @@ func Execute(options Options) {
 	p2pPrvKey := libp2pcrypto.Secp256k1PrivateKey(*prvKey)
 	id, err := peer.IDFromPublicKey((&p2pPrvKey).GetPublic())
 	failOnErr(err, "deriving peer ID from private key")
-	logger = logger.With(logging.HostID("node", id))
+	logger := utils.Logger().With(logging.HostID("node", id))
 
 	if options.DBPath == "" && options.UseDB {
 		failOnErr(errors.New("dbpath can't be null"), "")

--- a/waku/persistence/store_test.go
+++ b/waku/persistence/store_test.go
@@ -33,7 +33,7 @@ func createIndex(digest []byte, receiverTime int64) *pb.Index {
 func TestDbStore(t *testing.T) {
 	db := NewMock()
 	option := WithDB(db)
-	store, err := NewDBStore(utils.InitLogger("console"), option)
+	store, err := NewDBStore(utils.Logger(), option)
 	require.NoError(t, err)
 
 	res, err := store.GetAll()

--- a/waku/v2/discv5/discover_test.go
+++ b/waku/v2/discv5/discover_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func createHost(t *testing.T) (host.Host, int, *ecdsa.PrivateKey) {
-	utils.InitLogger("console")
+	utils.Logger()
 	privKey, err := gcrypto.GenerateKey()
 	require.NoError(t, err)
 

--- a/waku/v2/node/wakuoptions.go
+++ b/waku/v2/node/wakuoptions.go
@@ -92,7 +92,7 @@ type WakuNodeOption func(*WakuNodeParameters) error
 
 // Default options used in the libp2p node
 var DefaultWakuNodeOptions = []WakuNodeOption{
-	WithLogger(utils.InitLogger("console")),
+	WithLogger(utils.Logger()),
 	WithWakuRelay(),
 }
 

--- a/waku/v2/protocol/filter/waku_filter_option_test.go
+++ b/waku/v2/protocol/filter/waku_filter_option_test.go
@@ -25,7 +25,7 @@ func TestFilterOption(t *testing.T) {
 
 	params := new(FilterSubscribeParameters)
 	params.host = host
-	params.log = utils.InitLogger("console")
+	params.log = utils.Logger()
 
 	for _, opt := range options {
 		opt(params)

--- a/waku/v2/protocol/lightpush/waku_lightpush_option_test.go
+++ b/waku/v2/protocol/lightpush/waku_lightpush_option_test.go
@@ -27,7 +27,7 @@ func TestLightPushOption(t *testing.T) {
 
 	params := new(LightPushParameters)
 	params.host = host
-	params.log = utils.InitLogger("console")
+	params.log = utils.Logger()
 
 	for _, opt := range options {
 		opt(params)

--- a/waku/v2/protocol/relay/waku_relay_test.go
+++ b/waku/v2/protocol/relay/waku_relay_test.go
@@ -20,7 +20,7 @@ func TestWakuRelay(t *testing.T) {
 	host, err := tests.MakeHost(context.Background(), port, rand.Reader)
 	require.NoError(t, err)
 
-	relay, err := NewWakuRelay(context.Background(), host, nil, 0, utils.InitLogger("console"))
+	relay, err := NewWakuRelay(context.Background(), host, nil, 0, utils.Logger())
 	defer relay.Stop()
 	require.NoError(t, err)
 

--- a/waku/v2/protocol/store/waku_resume_test.go
+++ b/waku/v2/protocol/store/waku_resume_test.go
@@ -21,7 +21,7 @@ func TestFindLastSeenMessage(t *testing.T) {
 	msg4 := protocol.NewEnvelope(tests.CreateWakuMessage("4", 4), "test")
 	msg5 := protocol.NewEnvelope(tests.CreateWakuMessage("5", 5), "test")
 
-	s := NewWakuStore(nil, nil, nil, 0, 0, utils.InitLogger("console"))
+	s := NewWakuStore(nil, nil, nil, 0, 0, utils.Logger())
 	_ = s.storeMessage(msg1)
 	_ = s.storeMessage(msg3)
 	_ = s.storeMessage(msg5)

--- a/waku/v2/protocol/store/waku_store_query_test.go
+++ b/waku/v2/protocol/store/waku_store_query_test.go
@@ -43,7 +43,7 @@ func TestStoreQueryMultipleContentFilters(t *testing.T) {
 	msg2 := tests.CreateWakuMessage(topic2, 2)
 	msg3 := tests.CreateWakuMessage(topic3, 3)
 
-	s := NewWakuStore(nil, nil, nil, 0, 0, utils.InitLogger("console"))
+	s := NewWakuStore(nil, nil, nil, 0, 0, utils.Logger())
 	var err error
 	err = s.storeMessage(protocol.NewEnvelope(msg1, defaultPubSubTopic))
 	require.NoError(t, err)

--- a/waku/v2/protocol/swap/waku_swap_test.go
+++ b/waku/v2/protocol/swap/waku_swap_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestSwapCreditDebit(t *testing.T) {
-	swap := NewWakuSwap(utils.InitLogger("console"), []SwapOption{
+	swap := NewWakuSwap(utils.Logger(), []SwapOption{
 		WithMode(SoftMode),
 		WithThreshold(0, 0),
 	}...)

--- a/waku/v2/utils/logger.go
+++ b/waku/v2/utils/logger.go
@@ -25,12 +25,12 @@ func SetLogLevel(level string) error {
 // Logger creates a zap.Logger with some reasonable defaults
 func Logger() *zap.Logger {
 	if log == nil {
-		InitLogger("console").Panic("Logger not yet initialized")
+		InitLogger("console")
 	}
 	return log
 }
 
-func InitLogger(logEncoding string) *zap.Logger {
+func InitLogger(logEncoding string) {
 	cfg := zap.Config{
 		Encoding:         logEncoding,
 		Level:            atom,
@@ -53,5 +53,4 @@ func InitLogger(logEncoding string) *zap.Logger {
 	}
 
 	log = logger.Named("gowaku")
-	return log
 }

--- a/waku/v2/utils/logger.go
+++ b/waku/v2/utils/logger.go
@@ -26,6 +26,7 @@ func SetLogLevel(level string) error {
 func Logger() *zap.Logger {
 	if log == nil {
 		InitLogger("console")
+		log.Warn("logger not yet initialized")
 	}
 	return log
 }

--- a/waku/v2/utils/peer_test.go
+++ b/waku/v2/utils/peer_test.go
@@ -33,7 +33,7 @@ func TestSelectPeer(t *testing.T) {
 	h1.Peerstore().AddAddrs(h3.ID(), h2.Network().ListenAddresses(), peerstore.PermanentAddrTTL)
 
 	// No peers with selected protocol
-	_, err = SelectPeer(h1, proto, InitLogger("console"))
+	_, err = SelectPeer(h1, proto, Logger())
 	require.Error(t, ErrNoPeersAvailable, err)
 
 	// Peers with selected protocol


### PR DESCRIPTION
Upstream has moved towards lazy initialization of the global logger, and we can adopt that move without sacrificing the ability to set log encoding. This PR adopts most of the upstream setup, while preserving the `-log-encoding` option. It also tweaks the setup to match what was proposed in https://github.com/status-im/go-waku/pull/250, so if it gets adopted upstream, the merge should just eliminate all these differences. In the meantime it reduces unnecessary difference.
