### PR TITLE
Add gauge for host network peer count

### DIFF
--- a/waku/metrics/http.go
+++ b/waku/metrics/http.go
@@ -56,6 +56,7 @@ func NewMetricsServer(address string, port int, log *zap.Logger) *Server {
 		metrics.LightpushErrorTypesView,
 		metrics.StoreMessagesView,
 		metrics.PeersView,
+		metrics.NetworkPeersView,
 		metrics.DialsView,
 	); err != nil {
 		p.log.Fatal("registering views", zap.Error(err))

--- a/waku/v2/metrics/metrics.go
+++ b/waku/v2/metrics/metrics.go
@@ -13,6 +13,7 @@ import (
 var (
 	Messages            = stats.Int64("node_messages", "Number of messages received", stats.UnitDimensionless)
 	Peers               = stats.Int64("peers", "Number of connected peers", stats.UnitDimensionless)
+	NetworkPeers        = stats.Int64("network_peers", "Current count of host network peers", stats.UnitDimensionless)
 	Dials               = stats.Int64("dials", "Number of peer dials", stats.UnitDimensionless)
 	StoreMessages       = stats.Int64("store_messages", "Number of historical messages", stats.UnitDimensionless)
 	FilterSubscriptions = stats.Int64("filter_subscriptions", "Number of filter subscriptions", stats.UnitDimensionless)
@@ -31,6 +32,12 @@ var (
 		Measure:     Peers,
 		Description: "Number of connected peers",
 		Aggregation: view.Sum(),
+	}
+	NetworkPeersView = &view.View{
+		Name:        "gowaku_network_peers",
+		Measure:     NetworkPeers,
+		Description: "Current count of host network peers",
+		Aggregation: view.LastValue(),
 	}
 	DialsView = &view.View{
 		Name:        "gowaku_peers_dials",

--- a/waku/v2/node/wakunode2.go
+++ b/waku/v2/node/wakunode2.go
@@ -183,7 +183,7 @@ func New(ctx context.Context, opts ...WakuNodeOption) (*WakuNode, error) {
 
 	if w.opts.keepAliveInterval > time.Duration(0) {
 		w.wg.Add(1)
-		w.startKeepAlive(w.opts.keepAliveInterval)
+		w.startKeepAlive(ctx, w.opts.keepAliveInterval)
 	}
 
 	return w, nil


### PR DESCRIPTION
The `gowaku_connected_peers` is based on counting peer connects/disconnects and seems to yield odd results. My guess is that there are ways that clients can connect/disconnected that are just not captured by the current mechanism.

This PR is an experimental replacement that instead emits current `host.Network().Peers()` count (per node). I put it into the keepalive ping loop instead of spinning up a separate go-routine. In a separate PR I'll add some ping metrics if this works out.