### PR TITLE
Revert "Fix filter races"

### DIFF
--- a/waku/v2/protocol/filter/filter_subscribers.go
+++ b/waku/v2/protocol/filter/filter_subscribers.go
@@ -36,17 +36,6 @@ func (sub *Subscribers) Append(s Subscriber) int {
 	return len(sub.subscribers)
 }
 
-func (subs *Subscribers) SubscriberHasContentTopic(sub Subscriber, topic string) bool {
-	subs.RLock()
-	defer subs.RUnlock()
-	for _, filter := range sub.filter.ContentFilters {
-		if filter.ContentTopic == topic {
-			return true
-		}
-	}
-	return false
-}
-
 func (sub *Subscribers) Items() <-chan Subscriber {
 	c := make(chan Subscriber)
 
@@ -68,13 +57,6 @@ func (sub *Subscribers) Length() int {
 	defer sub.RUnlock()
 
 	return len(sub.subscribers)
-}
-
-func (sub *Subscribers) IsFailedPeer(peerID peer.ID) bool {
-	sub.RLock()
-	defer sub.RUnlock()
-	_, ok := sub.failedPeers[peerID]
-	return ok
 }
 
 func (sub *Subscribers) FlagAsSuccess(peerID peer.ID) {

--- a/waku/v2/protocol/filter/waku_filter.go
+++ b/waku/v2/protocol/filter/waku_filter.go
@@ -199,17 +199,21 @@ func (wf *WakuFilter) FilterListener() {
 				continue
 			}
 
-			if wf.subscribers.SubscriberHasContentTopic(subscriber, msg.ContentTopic) {
-				logger.Info("found matching content topic", zap.String("contentTopic", msg.ContentTopic))
-				// Do a message push to light node
-				logger.Info("pushing message to light node")
-				g.Go(func() (err error) {
-					err = wf.pushMessage(subscriber, msg)
-					if err != nil {
-						logger.Error("pushing message", zap.Error(err))
-					}
-					return err
-				})
+			for _, filter := range subscriber.filter.ContentFilters {
+				if msg.ContentTopic == filter.ContentTopic {
+					logger.Info("found matching content topic", zap.Stringer("filter", filter))
+					// Do a message push to light node
+					logger.Info("pushing message to light node")
+					g.Go(func() (err error) {
+						err = wf.pushMessage(subscriber, msg)
+						if err != nil {
+							logger.Error("pushing message", zap.Error(err))
+						}
+						return err
+					})
+					// Break if we have found a match
+					break
+				}
 			}
 		}
 

--- a/waku/v2/protocol/filter/waku_filter_test.go
+++ b/waku/v2/protocol/filter/waku_filter_test.go
@@ -175,7 +175,8 @@ func TestWakuFilterPeerFailure(t *testing.T) {
 	// Sleep to make sure the filter is subscribed
 	time.Sleep(2 * time.Second)
 
-	require.True(t, node2Filter.subscribers.IsFailedPeer(host1.ID()))
+	_, ok := node2Filter.subscribers.failedPeers[host1.ID()]
+	require.True(t, ok)
 
 	var wg sync.WaitGroup
 
@@ -186,7 +187,8 @@ func TestWakuFilterPeerFailure(t *testing.T) {
 		require.Equal(t, contentFilter.ContentTopics[0], env.Message().GetContentTopic())
 
 		// Failure is removed
-		require.False(t, node2Filter.subscribers.IsFailedPeer(host1.ID()))
+		_, ok := node2Filter.subscribers.failedPeers[host1.ID()]
+		require.False(t, ok)
 
 	}()
 
@@ -204,8 +206,9 @@ func TestWakuFilterPeerFailure(t *testing.T) {
 	require.NoError(t, err)
 
 	// TODO: find out how to eliminate this sleep
-	time.Sleep(1 * time.Second)
-	require.True(t, node2Filter.subscribers.IsFailedPeer(host1.ID()))
+	time.Sleep(3 * time.Second)
+	_, ok = node2Filter.subscribers.failedPeers[host1.ID()]
+	require.True(t, ok)
 
 	time.Sleep(3 * time.Second)
 
@@ -213,7 +216,8 @@ func TestWakuFilterPeerFailure(t *testing.T) {
 	require.NoError(t, err)
 
 	time.Sleep(1 * time.Second)
-	require.False(t, node2Filter.subscribers.IsFailedPeer(host1.ID())) // Failed peer has been removed
+	_, ok = node2Filter.subscribers.failedPeers[host1.ID()]
+	require.False(t, ok) // Failed peer has been removed
 
 	for subscriber := range node2Filter.subscribers.Items() {
 		if subscriber.peer == node1.h.ID() {


### PR DESCRIPTION
The [sync docs](https://pkg.go.dev/sync#RWMutex) say:
>  If a goroutine holds a RWMutex for reading and another goroutine might call Lock, no goroutine should expect to be able to acquire a read lock until the initial read lock is released. In particular, this prohibits recursive read locking. This is to ensure that the lock eventually becomes available; a blocked Lock call excludes new readers from acquiring the lock.

The change to `SubscriberHasContentTopic` introduces a recursive read lock when it is called inside `Items()` (which also acquires a read lock for the duration of the iteration). This looks like it is causing deadlocks, leading to the filter protocol becoming unavailable.

Reverts xmtp/go-waku#19