### PR TITLE
Fix store error metrics tagging

### DIFF
--- a/waku/v2/metrics/metrics.go
+++ b/waku/v2/metrics/metrics.go
@@ -69,7 +69,7 @@ var (
 		Measure:     StoreErrors,
 		Description: "The distribution of the store protocol errors",
 		Aggregation: view.Count(),
-		TagKeys:     []tag.Key{KeyType},
+		TagKeys:     []tag.Key{ErrorType},
 	}
 	LightpushErrorTypesView = &view.View{
 		Name:        "gowaku_lightpush_errors",


### PR DESCRIPTION
Register view with tag key `ErrorType` instead of `KeyType`, since `ErrorType` is what the metric is [emitted with](https://github.com/xmtp/go-waku/blob/master/waku/v2/metrics/metrics.go#L95-L99).