### PR TITLE
Fix issue removing subscriptions

### DIFF
--- a/waku/v2/protocol/filter/filter_subscribers.go
+++ b/waku/v2/protocol/filter/filter_subscribers.go
@@ -132,7 +132,7 @@ func (sub *Subscribers) RemoveContentFilters(peerID peer.ID, contentFilters []*p
 			for i, cf := range subCfs {
 				if cf.ContentTopic == contentFilter.ContentTopic {
 					l := len(subCfs) - 1
-					subCfs[l], subCfs[i] = subCfs[i], subCfs[l]
+					subCfs[i] = subCfs[l]
 					subscriber.filter.ContentFilters = subCfs[:l]
 				}
 			}

--- a/waku/v2/protocol/filter/filter_subscribers.go
+++ b/waku/v2/protocol/filter/filter_subscribers.go
@@ -1,7 +1,6 @@
 package filter
 
 import (
-	"fmt"
 	"sync"
 	"time"
 
@@ -148,7 +147,6 @@ func (sub *Subscribers) RemoveContentFilters(peerID peer.ID, contentFilters []*p
 	// make sure we delete the subscriber
 	// if no more content filters left
 	for _, peerId := range peerIdsToRemove {
-		fmt.Println("Removing peer")
 		for i, s := range sub.subscribers {
 			if s.peer == peerId {
 				l := len(sub.subscribers) - 1

--- a/waku/v2/protocol/filter/filter_subscribers.go
+++ b/waku/v2/protocol/filter/filter_subscribers.go
@@ -130,13 +130,13 @@ func (sub *Subscribers) RemoveContentFilters(peerID peer.ID, contentFilters []*p
 		// if no more topics are left
 		for _, contentFilter := range contentFilters {
 			subCfs := subscriber.filter.ContentFilters
-			var out []*pb.FilterRequest_ContentFilter
-			for _, cf := range subCfs {
-				if cf.ContentTopic != contentFilter.ContentTopic {
-					out = append(out, cf)
+			for i, cf := range subCfs {
+				if cf.ContentTopic == contentFilter.ContentTopic {
+					l := len(subCfs) - 1
+					subCfs[l], subCfs[i] = subCfs[i], subCfs[l]
+					subscriber.filter.ContentFilters = subCfs[:l]
 				}
 			}
-			subscriber.filter.ContentFilters = out
 			sub.subscribers[subIndex] = subscriber
 		}
 

--- a/waku/v2/protocol/filter/filter_subscribers.go
+++ b/waku/v2/protocol/filter/filter_subscribers.go
@@ -127,9 +127,9 @@ func (sub *Subscribers) RemoveContentFilters(peerID peer.ID, contentFilters []*p
 
 		// make sure we delete the content filter
 		// if no more topics are left
-		for i, contentFilter := range contentFilters {
+		for _, contentFilter := range contentFilters {
 			subCfs := subscriber.filter.ContentFilters
-			for _, cf := range subCfs {
+			for i, cf := range subCfs {
 				if cf.ContentTopic == contentFilter.ContentTopic {
 					l := len(subCfs) - 1
 					subCfs[l], subCfs[i] = subCfs[i], subCfs[l]

--- a/waku/v2/protocol/filter/filter_subscribers_test.go
+++ b/waku/v2/protocol/filter/filter_subscribers_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/test"
 	"github.com/status-im/go-waku/waku/v2/protocol/pb"
 	"github.com/stretchr/testify/assert"
@@ -11,10 +12,15 @@ import (
 
 const TOPIC = "/test/topic"
 
-func TestAppend(t *testing.T) {
-	subs := NewSubscribers(10 * time.Second)
+func createPeerId(t *testing.T) peer.ID {
 	peerId, err := test.RandPeerID()
 	assert.NoError(t, err)
+	return peerId
+}
+
+func TestAppend(t *testing.T) {
+	subs := NewSubscribers(10 * time.Second)
+	peerId := createPeerId(t)
 	contentTopic := "topic1"
 	request := pb.FilterRequest{
 		Subscribe:      true,
@@ -32,8 +38,7 @@ func TestAppend(t *testing.T) {
 
 func TestRemove(t *testing.T) {
 	subs := NewSubscribers(10 * time.Second)
-	peerId, err := test.RandPeerID()
-	assert.NoError(t, err)
+	peerId := createPeerId(t)
 	contentTopic := "topic1"
 	request := pb.FilterRequest{
 		Subscribe:      true,
@@ -52,8 +57,7 @@ func TestRemove(t *testing.T) {
 
 func TestRemovePartial(t *testing.T) {
 	subs := NewSubscribers(10 * time.Second)
-	peerId, err := test.RandPeerID()
-	assert.NoError(t, err)
+	peerId := createPeerId(t)
 	topic1 := "topic1"
 	topic2 := "topic2"
 	request := pb.FilterRequest{
@@ -74,8 +78,7 @@ func TestRemovePartial(t *testing.T) {
 
 func TestRemoveBogus(t *testing.T) {
 	subs := NewSubscribers(10 * time.Second)
-	peerId, err := test.RandPeerID()
-	assert.NoError(t, err)
+	peerId := createPeerId(t)
 	contentTopic := "topic1"
 	request := pb.FilterRequest{
 		Subscribe:      true,

--- a/waku/v2/protocol/filter/filter_subscribers_test.go
+++ b/waku/v2/protocol/filter/filter_subscribers_test.go
@@ -26,7 +26,6 @@ func TestAppend(t *testing.T) {
 	var hasMatch bool
 	for range subs.Items(&contentTopic) {
 		hasMatch = true
-		break
 	}
 	assert.True(t, hasMatch)
 }
@@ -47,7 +46,6 @@ func TestRemove(t *testing.T) {
 	var hasMatch bool
 	for range subs.Items(&contentTopic) {
 		hasMatch = true
-		break
 	}
 	assert.False(t, hasMatch)
 }
@@ -66,4 +64,10 @@ func TestRemoveBogus(t *testing.T) {
 	// This will panic with this error:
 	// panic: runtime error: index out of range [1] with length 1
 	subs.RemoveContentFilters(peerId, []*pb.FilterRequest_ContentFilter{{ContentTopic: "does not exist"}, {ContentTopic: contentTopic}})
+
+	var hasMatch bool
+	for range subs.Items(&contentTopic) {
+		hasMatch = true
+	}
+	assert.False(t, hasMatch)
 }

--- a/waku/v2/protocol/filter/filter_subscribers_test.go
+++ b/waku/v2/protocol/filter/filter_subscribers_test.go
@@ -62,10 +62,10 @@ func TestRemovePartial(t *testing.T) {
 		ContentFilters: []*pb.FilterRequest_ContentFilter{{ContentTopic: topic1}, {ContentTopic: topic2}},
 	}
 	subs.Append(Subscriber{peerId, "request_1", request})
-	subs.RemoveContentFilters(peerId, []*pb.FilterRequest_ContentFilter{{ContentTopic: "topic1"}})
+	subs.RemoveContentFilters(peerId, []*pb.FilterRequest_ContentFilter{{ContentTopic: topic1}})
 
 	var hasMatch bool
-	for sub := range subs.Items(&topic1) {
+	for sub := range subs.Items(&topic2) {
 		hasMatch = true
 		assert.Len(t, sub.filter.ContentFilters, 1)
 	}

--- a/waku/v2/protocol/filter/filter_subscribers_test.go
+++ b/waku/v2/protocol/filter/filter_subscribers_test.go
@@ -1,0 +1,69 @@
+package filter
+
+import (
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p-core/test"
+	"github.com/status-im/go-waku/waku/v2/protocol/pb"
+	"github.com/stretchr/testify/assert"
+)
+
+const TOPIC = "/test/topic"
+
+func TestAppend(t *testing.T) {
+	subs := NewSubscribers(10 * time.Second)
+	peerId, err := test.RandPeerID()
+	assert.NoError(t, err)
+	contentTopic := "topic1"
+	request := pb.FilterRequest{
+		Subscribe:      true,
+		Topic:          TOPIC,
+		ContentFilters: []*pb.FilterRequest_ContentFilter{{ContentTopic: contentTopic}},
+	}
+	subs.Append(Subscriber{peerId, "request_1", request})
+
+	var hasMatch bool
+	for range subs.Items(&contentTopic) {
+		hasMatch = true
+		break
+	}
+	assert.True(t, hasMatch)
+}
+
+func TestRemove(t *testing.T) {
+	subs := NewSubscribers(10 * time.Second)
+	peerId, err := test.RandPeerID()
+	assert.NoError(t, err)
+	contentTopic := "topic1"
+	request := pb.FilterRequest{
+		Subscribe:      true,
+		Topic:          TOPIC,
+		ContentFilters: []*pb.FilterRequest_ContentFilter{{ContentTopic: contentTopic}},
+	}
+	subs.Append(Subscriber{peerId, "request_1", request})
+	subs.RemoveContentFilters(peerId, request.ContentFilters)
+
+	var hasMatch bool
+	for range subs.Items(&contentTopic) {
+		hasMatch = true
+		break
+	}
+	assert.False(t, hasMatch)
+}
+
+func TestRemoveBogus(t *testing.T) {
+	subs := NewSubscribers(10 * time.Second)
+	peerId, err := test.RandPeerID()
+	assert.NoError(t, err)
+	contentTopic := "topic1"
+	request := pb.FilterRequest{
+		Subscribe:      true,
+		Topic:          TOPIC,
+		ContentFilters: []*pb.FilterRequest_ContentFilter{{ContentTopic: contentTopic}},
+	}
+	subs.Append(Subscriber{peerId, "request_1", request})
+	// This will panic with this error:
+	// panic: runtime error: index out of range [1] with length 1
+	subs.RemoveContentFilters(peerId, []*pb.FilterRequest_ContentFilter{{ContentTopic: "does not exist"}, {ContentTopic: contentTopic}})
+}


### PR DESCRIPTION
## Summary
- Add some missing tests to the FilterSubscribers file
- Add a test for removing a subscription for a topic that was not already subscribed
- Uses the correct index to remove filters from the list
- This is in response to https://github.com/xmtp/xmtp-js/issues/139

## Notes
- This PR will be re-created against the upstream main once merged