### PR TITLE
Clean up ENR localNode DB

### DIFF
--- a/waku/v2/node/wakunode2.go
+++ b/waku/v2/node/wakunode2.go
@@ -346,6 +346,10 @@ func (w *WakuNode) Stop() {
 	w.host.Close()
 
 	w.wg.Wait()
+
+	if w.localNode != nil {
+		w.localNode.Database().Close()
+	}
 }
 
 // Host returns the libp2p Host used by the WakuNode


### PR DESCRIPTION
Close ENR localnode DB during node tear down and address change, otherwise memory usage accrues pretty quickly if you're creating and tearing down a bunch of nodes in process.

![heap](https://user-images.githubusercontent.com/182290/181521844-987f8f42-07ec-496d-a9ac-c31676e1625d.png)

Upstream PR: https://github.com/status-im/go-waku/pull/279