### PR TITLE
Verify matching `requestId` before removing subscription

### DIFF
--- a/waku/v2/protocol/filter/filter_subscribers.go
+++ b/waku/v2/protocol/filter/filter_subscribers.go
@@ -114,14 +114,14 @@ func (sub *Subscribers) FlagAsFailure(peerID peer.ID) {
 	}
 }
 
-func (sub *Subscribers) RemoveContentFilters(peerID peer.ID, contentFilters []*pb.FilterRequest_ContentFilter) {
+func (sub *Subscribers) RemoveContentFilters(peerID peer.ID, requestId string, contentFilters []*pb.FilterRequest_ContentFilter) {
 	sub.Lock()
 	defer sub.Unlock()
 
 	var peerIdsToRemove []peer.ID
 
 	for subIndex, subscriber := range sub.subscribers {
-		if subscriber.peer != peerID {
+		if subscriber.peer != peerID || subscriber.requestId != requestId {
 			continue
 		}
 

--- a/waku/v2/protocol/filter/filter_subscribers.go
+++ b/waku/v2/protocol/filter/filter_subscribers.go
@@ -148,11 +148,10 @@ func (sub *Subscribers) RemoveContentFilters(peerID peer.ID, requestId string, c
 	// if no more content filters left
 	for _, peerId := range peerIdsToRemove {
 		for i, s := range sub.subscribers {
-			if s.peer == peerId {
+			if s.peer == peerId && s.requestId == requestId {
 				l := len(sub.subscribers) - 1
-				sub.subscribers[l], sub.subscribers[i] = sub.subscribers[i], sub.subscribers[l]
+				sub.subscribers[i] = sub.subscribers[l]
 				sub.subscribers = sub.subscribers[:l]
-				break
 			}
 		}
 	}

--- a/waku/v2/protocol/filter/filter_subscribers_test.go
+++ b/waku/v2/protocol/filter/filter_subscribers_test.go
@@ -58,27 +58,7 @@ func TestRemove(t *testing.T) {
 	assert.Nil(t, sub)
 }
 
-func TestRemoveMultipleTopics(t *testing.T) {
-	subs := NewSubscribers(10 * time.Second)
-	peerId := createPeerId(t)
-	requestId := "request_1"
-	topic1 := "topic1"
-	topic2 := "topic2"
-	request := pb.FilterRequest{
-		Subscribe:      true,
-		Topic:          TOPIC,
-		ContentFilters: []*pb.FilterRequest_ContentFilter{{ContentTopic: topic1}, {ContentTopic: topic2}},
-	}
-	subs.Append(Subscriber{peerId, requestId, request})
-	subs.RemoveContentFilters(peerId, requestId, []*pb.FilterRequest_ContentFilter{{ContentTopic: topic1}, {ContentTopic: topic2}})
-
-	sub1 := firstSubscriber(subs, topic1)
-	sub2 := firstSubscriber(subs, topic2)
-	assert.Nil(t, sub1)
-	assert.Nil(t, sub2)
-}
-
-func TestRemoveDuplicateFilters(t *testing.T) {
+func TestRemoveDuplicateSubscriptions(t *testing.T) {
 	subs := NewSubscribers(10 * time.Second)
 	peerId := createPeerId(t)
 	topic := "topic"

--- a/waku/v2/protocol/filter/filter_subscribers_test.go
+++ b/waku/v2/protocol/filter/filter_subscribers_test.go
@@ -58,7 +58,51 @@ func TestRemove(t *testing.T) {
 	assert.Nil(t, sub)
 }
 
+func TestRemovePartial(t *testing.T) {
+	subs := NewSubscribers(10 * time.Second)
+	peerId := createPeerId(t)
+	requestId := "request_1"
+	topic1 := "topic1"
+	topic2 := "topic2"
+	request := pb.FilterRequest{
+		Subscribe:      true,
+		Topic:          TOPIC,
+		ContentFilters: []*pb.FilterRequest_ContentFilter{{ContentTopic: topic1}, {ContentTopic: topic2}},
+	}
+	subs.Append(Subscriber{peerId, requestId, request})
+	subs.RemoveContentFilters(peerId, requestId, []*pb.FilterRequest_ContentFilter{{ContentTopic: topic1}})
+
+	sub := firstSubscriber(subs, topic2)
+	assert.NotNil(t, sub)
+	assert.Len(t, sub.filter.ContentFilters, 1)
+}
+
 func TestRemoveDuplicateSubscriptions(t *testing.T) {
+	subs := NewSubscribers(10 * time.Second)
+	peerId := createPeerId(t)
+	topic := "topic"
+	requestId1 := "request_1"
+	requestId2 := "request_2"
+	request1 := pb.FilterRequest{
+		Subscribe:      true,
+		Topic:          TOPIC,
+		ContentFilters: []*pb.FilterRequest_ContentFilter{{ContentTopic: topic}},
+	}
+	request2 := pb.FilterRequest{
+		Subscribe:      true,
+		Topic:          TOPIC,
+		ContentFilters: []*pb.FilterRequest_ContentFilter{{ContentTopic: topic}},
+	}
+	subs.Append(Subscriber{peerId, requestId1, request1})
+	subs.Append(Subscriber{peerId, requestId2, request2})
+	subs.RemoveContentFilters(peerId, requestId2, []*pb.FilterRequest_ContentFilter{{ContentTopic: topic}})
+	subs.RemoveContentFilters(peerId, requestId1, []*pb.FilterRequest_ContentFilter{{ContentTopic: topic}})
+
+	sub := firstSubscriber(subs, topic)
+	assert.Nil(t, sub)
+}
+
+func TestRemoveDuplicateSubscriptionsPartial(t *testing.T) {
 	subs := NewSubscribers(10 * time.Second)
 	peerId := createPeerId(t)
 	topic := "topic"
@@ -81,25 +125,6 @@ func TestRemoveDuplicateSubscriptions(t *testing.T) {
 	sub := firstSubscriber(subs, topic)
 	assert.NotNil(t, sub)
 	assert.Equal(t, sub.requestId, requestId2)
-}
-
-func TestRemovePartial(t *testing.T) {
-	subs := NewSubscribers(10 * time.Second)
-	peerId := createPeerId(t)
-	requestId := "request_1"
-	topic1 := "topic1"
-	topic2 := "topic2"
-	request := pb.FilterRequest{
-		Subscribe:      true,
-		Topic:          TOPIC,
-		ContentFilters: []*pb.FilterRequest_ContentFilter{{ContentTopic: topic1}, {ContentTopic: topic2}},
-	}
-	subs.Append(Subscriber{peerId, requestId, request})
-	subs.RemoveContentFilters(peerId, requestId, []*pb.FilterRequest_ContentFilter{{ContentTopic: topic1}})
-
-	sub := firstSubscriber(subs, topic2)
-	assert.NotNil(t, sub)
-	assert.Len(t, sub.filter.ContentFilters, 1)
 }
 
 func TestRemoveBogus(t *testing.T) {

--- a/waku/v2/protocol/filter/waku_filter.go
+++ b/waku/v2/protocol/filter/waku_filter.go
@@ -132,7 +132,7 @@ func (wf *WakuFilter) onRequest(s network.Stream) {
 			stats.Record(wf.ctx, metrics.FilterSubscriptions.M(int64(len)))
 		} else {
 			peerId := s.Conn().RemotePeer()
-			wf.subscribers.RemoveContentFilters(peerId, filterRPCRequest.Request.ContentFilters)
+			wf.subscribers.RemoveContentFilters(peerId, filterRPCRequest.RequestId, filterRPCRequest.Request.ContentFilters)
 
 			logger.Info("removing subscriber")
 			stats.Record(wf.ctx, metrics.FilterSubscriptions.M(int64(wf.subscribers.Length())))


### PR DESCRIPTION
### Summary

This PR updates the `unsubscribe` function to only remove subscriptions for topics that have a matching `requestId`. This resolves an issue where subscribing to the same content topic in two requests (request id 1 & 2) and calling unsubscribe in request 2 would also unsubscribe request 1.

Now a client can subscribe to the same content topic in two requests (request id 1 & 2), unsubscribe from one (request id 2) and request id 1 will stay subscribed.

### Notes

This PR will be recreated upstream on `status-im/go-waku` once merged.