### PR TITLE
Fix relay goroutine leaks

### DIFF
--- a/waku/v2/node/wakuoptions.go
+++ b/waku/v2/node/wakuoptions.go
@@ -246,6 +246,14 @@ func WithWakuRelayAndMinPeers(minRelayPeersToPublish int, opts ...pubsub.Option)
 	}
 }
 
+// WithoutWakuRelay disables the Waku V2 Relay protocol.
+func WithoutWakuRelay() WakuNodeOption {
+	return func(params *WakuNodeParameters) error {
+		params.enableRelay = false
+		return nil
+	}
+}
+
 // WithDiscoveryV5 is a WakuOption used to enable DiscV5 peer discovery
 func WithDiscoveryV5(udpPort int, bootnodes []*enode.Node, autoUpdate bool, discoverOpts ...pubsub.DiscoverOpt) WakuNodeOption {
 	return func(params *WakuNodeParameters) error {

--- a/waku/v2/protocol/relay/waku_relay.go
+++ b/waku/v2/protocol/relay/waku_relay.go
@@ -33,6 +33,9 @@ type WakuRelay struct {
 
 	log *zap.Logger
 
+	ctx       context.Context
+	ctxCancel func()
+
 	bcaster v2.Broadcaster
 
 	minPeersToPublish int
@@ -62,6 +65,7 @@ func NewWakuRelay(ctx context.Context, h host.Host, bcaster v2.Broadcaster, minP
 	w.bcaster = bcaster
 	w.minPeersToPublish = minPeersToPublish
 	w.log = log.Named("relay")
+	w.ctx, w.ctxCancel = context.WithCancel(ctx)
 
 	// default options required by WakuRelay
 	opts = append(opts, pubsub.WithMessageSignaturePolicy(pubsub.StrictNoSign))
@@ -82,7 +86,7 @@ func NewWakuRelay(ctx context.Context, h host.Host, bcaster v2.Broadcaster, minP
 		},
 	))
 
-	ps, err := pubsub.NewGossipSub(ctx, h, opts...)
+	ps, err := pubsub.NewGossipSub(w.ctx, h, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -204,6 +208,8 @@ func (w *WakuRelay) Stop() {
 		}
 	}
 	w.subscriptions = nil
+
+	w.ctxCancel()
 }
 
 // EnoughPeersToPublish returns whether there are enough peers connected in the default waku pubsub topic
@@ -301,7 +307,7 @@ func (w *WakuRelay) nextMessage(ctx context.Context, sub *pubsub.Subscription) <
 }
 
 func (w *WakuRelay) subscribeToTopic(t string, subscription *Subscription, sub *pubsub.Subscription) {
-	ctx, err := tag.New(context.Background(), tag.Insert(metrics.KeyType, "relay"))
+	ctx, err := tag.New(w.ctx, tag.Insert(metrics.KeyType, "relay"))
 	if err != nil {
 		w.log.Error("creating tag map", zap.Error(err))
 		return


### PR DESCRIPTION
This PR fixes a couple goroutine leaks in the relay, which were causing unbounded memory growth in processes that create/destroy client nodes over time:
1. Allow pubsub `.Next(ctx)` to exit by passing it a cancellable context that's cancelled during relay `Stop()`
2. Allow relay broadcaster `WaitUnregister` and `Unregister` to exit by checking to see if the broadcaster has been closed already, along with the goroutine that would consume from the blocking channel that these 2 methods send to

The PR also adds a `WithoutWakuRelay` node option to support a node client without relay enabled, since `WithWakuRelay` is given to the set of `DefaultWakuNodeOptions`.

Note that there's also a goroutine leak in the libp2p NAT service enabled via [libp2p.EnableNATService()](https://github.com/status-im/go-waku/blob/master/waku/v2/node/wakuoptions.go#L420), but this PR does not address that.

## Before 
![goroutine](https://user-images.githubusercontent.com/182290/183897042-59a0898b-f8f4-4d8f-82e5-1d3943f6e54f.png)

## After disabling libp2p NAT service

![goroutine](https://user-images.githubusercontent.com/182290/183897648-e7e374a7-2a52-4d29-825e-ee44ffa49d31.png)

## After (1)

![goroutine](https://user-images.githubusercontent.com/182290/183898154-d91bbd30-882a-4fb9-bd52-856a2cfbf591.png)

## After (2)

![goroutine](https://user-images.githubusercontent.com/182290/183910478-357bcc6e-4a43-4073-8781-2806984e34e5.png)

Upstream PR: https://github.com/status-im/go-waku/pull/286