### PR TITLE
Return out of relay subscription loop on unsubscribe

### DIFF
--- a/waku/v2/dnsdisc/enr_test.go
+++ b/waku/v2/dnsdisc/enr_test.go
@@ -10,7 +10,7 @@ import (
 // TestRetrieveNodes uses a live connection, so it could be
 // flaky, it should though pay for itself and should be fairly stable
 func TestRetrieveNodes(t *testing.T) {
-	url := "enrtree://AOFTICU2XWDULNLZGRMQS4RIZPAZEHYMV4FYHAPW563HNRAOERP7C@test.waku.nodes.status.im"
+	url := "enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@test.waku.nodes.status.im"
 
 	nodes, err := RetrieveNodes(context.Background(), url)
 	require.NoError(t, err)

--- a/waku/v2/protocol/relay/subscription.go
+++ b/waku/v2/protocol/relay/subscription.go
@@ -16,6 +16,7 @@ type Subscription struct {
 	closed bool
 	once   sync.Once
 	quit   chan struct{}
+	wg     sync.WaitGroup
 }
 
 // Unsubscribe will close a subscription from a pubsub topic. Will close the message channel
@@ -23,7 +24,7 @@ func (subs *Subscription) Unsubscribe() {
 	subs.once.Do(func() {
 		close(subs.quit)
 	})
-
+	subs.wg.Wait()
 }
 
 // IsClosed determine whether a Subscription is still open for receiving messages

--- a/waku/v2/protocol/relay/waku_relay.go
+++ b/waku/v2/protocol/relay/waku_relay.go
@@ -247,6 +247,7 @@ func (w *WakuRelay) SubscribeToTopic(ctx context.Context, topic string) (*Subscr
 		w.bcaster.Register(&topic, subscription.C)
 	}
 
+	subscription.wg.Add(1)
 	go w.subscribeToTopic(topic, subscription, sub)
 
 	return subscription, nil
@@ -307,6 +308,8 @@ func (w *WakuRelay) nextMessage(ctx context.Context, sub *pubsub.Subscription) <
 }
 
 func (w *WakuRelay) subscribeToTopic(t string, subscription *Subscription, sub *pubsub.Subscription) {
+	defer subscription.wg.Done()
+
 	ctx, err := tag.New(w.ctx, tag.Insert(metrics.KeyType, "relay"))
 	if err != nil {
 		w.log.Error("creating tag map", zap.Error(err))
@@ -318,13 +321,13 @@ func (w *WakuRelay) subscribeToTopic(t string, subscription *Subscription, sub *
 	for {
 		select {
 		case <-subscription.quit:
+			if subscription.closed {
+				return
+			}
 			func(topic string) {
 				subscription.Lock()
 				defer subscription.Unlock()
 
-				if subscription.closed {
-					return
-				}
 				subscription.closed = true
 				if w.bcaster != nil {
 					<-w.bcaster.WaitUnregister(&topic, subscription.C) // Remove from broadcast list

--- a/waku/v2/protocol/relay/waku_relay_test.go
+++ b/waku/v2/protocol/relay/waku_relay_test.go
@@ -51,3 +51,22 @@ func TestWakuRelay(t *testing.T) {
 
 	<-ctx.Done()
 }
+
+func TestWakuRelay_Unsubscribe(t *testing.T) {
+	testTopic := "/waku/2/go/relay/test"
+
+	port, err := tests.FindFreePort(t, "", 5)
+	require.NoError(t, err)
+
+	host, err := tests.MakeHost(context.Background(), port, rand.Reader)
+	require.NoError(t, err)
+
+	relay, err := NewWakuRelay(context.Background(), host, nil, 0, utils.Logger())
+	defer relay.Stop()
+	require.NoError(t, err)
+
+	sub, err := relay.SubscribeToTopic(context.Background(), testTopic)
+	require.NoError(t, err)
+
+	sub.Unsubscribe()
+}


### PR DESCRIPTION
Fix return out of the relay subscription `subscribeToTopic` loop, where it was previously just returning out of the inner method and getting stuck in the `for { }`, resulting in very high CPU usage when `Unsubscribe` was called. The PR also adds a WaitGroup to the Subscription struct that's used just for this goroutine, and waits on unsubscribe, so that the behaviour could be tested.